### PR TITLE
Fix stack version check

### DIFF
--- a/src/SHC/Utils.hs
+++ b/src/SHC/Utils.hs
@@ -57,7 +57,7 @@ getRemotes = nubBy ((==) `on` name) <$> parseRemotes <$> git ["remote", "-v"]
 -- | Verify that the required Stack is present.
 checkStackVersion :: IO Bool
 checkStackVersion = do
-    let lowerBound = makeVersion [0,1,7,0]
+    let lowerBound = Version [0,1,7,0] []
     stackVersion <- stack ["--numeric-version"]
     return $ verifyVersion stackVersion lowerBound
 

--- a/src/SHC/Utils.hs
+++ b/src/SHC/Utils.hs
@@ -14,9 +14,11 @@ module SHC.Utils
 import           Control.Monad       (guard)
 import           Data.Function       (on)
 import           Data.List
+import           Data.Version
 #if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative ((<$>), (<*>))
 #endif
+import           Text.ParserCombinators.ReadP
 import           System.FilePath     ((</>))
 import           System.Process      (readProcess)
 
@@ -54,7 +56,17 @@ getRemotes = nubBy ((==) `on` name) <$> parseRemotes <$> git ["remote", "-v"]
 
 -- | Verify that the required Stack is present.
 checkStackVersion :: IO Bool
-checkStackVersion = ("0.1.7.0" <=) <$> stack ["--numeric-version"]
+checkStackVersion = do
+    let lowerBound = makeVersion [0,1,7,0]
+    stackVersion <- stack ["--numeric-version"]
+    return $ verifyVersion stackVersion lowerBound
+
+-- | Check whether a string is a version and if it is
+-- greater than or equal to a specified version.
+verifyVersion :: String -> Version -> Bool
+verifyVersion ver lowerBound =
+        let parses = readP_to_S parseVersion ver
+        in  not (null parses) && (lowerBound <= fst (last parses))
 
 -- | Return the HPC data directory, given the package name.
 getHpcDir :: String -> IO FilePath

--- a/test/SHCSpec.hs
+++ b/test/SHCSpec.hs
@@ -91,7 +91,7 @@ spec = do
             toLix 4 covEntries `shouldBe` [Partial, Full, Irrelevant, None]
     describe "SHC.Utils" $ do
         it "verifyVersion" $
-            let ver = makeVersion [0,1,7,0]
+            let ver = Version [0,1,7,0] []
             in  (not (verifyVersion "0.1.6.0" ver) &&
                  verifyVersion "0.1.7.0" ver &&
                  verifyVersion "1.100.4.56" ver) `shouldBe` True

--- a/test/SHCSpec.hs
+++ b/test/SHCSpec.hs
@@ -10,6 +10,7 @@ import           Control.Exception        (evaluate)
 import           Data.Aeson
 import qualified Data.Map.Strict          as M
 import           Data.Time.Clock          (getCurrentTime)
+import           Data.Version
 import           System.IO.Unsafe         (unsafePerformIO)
 import           Test.Hspec
 import           Test.Hspec.Contrib.HUnit
@@ -89,6 +90,11 @@ spec = do
         it "toLix" $
             toLix 4 covEntries `shouldBe` [Partial, Full, Irrelevant, None]
     describe "SHC.Utils" $ do
+        it "verifyVersion" $
+            let ver = makeVersion [0,1,7,0]
+            in  (not (verifyVersion "0.1.6.0" ver) &&
+                 verifyVersion "0.1.7.0" ver &&
+                 verifyVersion "1.100.4.56" ver) `shouldBe` True
         it "fst3" $ fst3 (1, 2, 3) `shouldBe` 1
         it "snd3" $ snd3 (1, 2, 3) `shouldBe` 2
         it "trd3" $ trd3 (1, 2, 3) `shouldBe` 3


### PR DESCRIPTION
The latest stack, version 0.1.10.0, does not work with shc because of the version check (woops :P).

It checks if **"0.1.7.0" <= "0.1.10.0"** which is False. 

This change is a more robust version check, I added a test here too, just in case! 
