### PR TITLE
Support multiple projects + misc fixes

### DIFF
--- a/USAGE.txt
+++ b/USAGE.txt
@@ -8,6 +8,7 @@ Options:
     --repo-token=<token>  Coveralls repo token
     --partial-coverage    allow partial line coverage
     --dont-send           display Coveralls JSON instead of sending it
+    --fetch-coverage      fetch and display Coveralls's overall coverage
 
 Multiple packages:
      Use "combined" and "all" as package-name and suite-name resp. in

--- a/USAGE.txt
+++ b/USAGE.txt
@@ -8,3 +8,8 @@ Options:
     --repo-token=<token>  Coveralls repo token
     --partial-coverage    allow partial line coverage
     --dont-send           display Coveralls JSON instead of sending it
+
+Multiple packages:
+     Use "combined" and "all" as package-name and suite-name resp. in
+order to use all packages that stack has tested from a multiple
+package repo.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -64,7 +64,7 @@ getConfig args = do
            <*> pure (args `getArg` longOption "repo-token")
            <*> getGitInfo
            <*> defaultOr args (longOption "hpc-dir") (getHpcDir pn)
-           <*> pure (maybe getMixDir (const . return) $ args `getArg` longOption "mix-dir")
+           <*> pure (args `getArg` longOption "mix-dir")
            <*> pure (if args `isPresent` longOption "partial-coverage"
                         then PartialLines
                         else FullLines)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -18,6 +18,7 @@ import           System.Exit           (exitFailure)
 
 import           SHC.Api
 import           SHC.Coverage
+import           SHC.Stack
 import           SHC.Types
 import           SHC.Utils
 
@@ -56,7 +57,8 @@ getConfig args = do
     unless (not $ null suites) $
         putStrLn "Error: provide at least one test-suite name" >> exitFailure
     (sn, jId) <- getServiceAndJobId
-    Config <$> pure suites
+    Config <$> pure pn
+           <*> pure suites
            <*> pure sn
            <*> pure jId
            <*> pure (args `getArg` longOption "repo-token")
@@ -66,6 +68,7 @@ getConfig args = do
            <*> pure (if args `isPresent` longOption "partial-coverage"
                         then PartialLines
                         else FullLines)
+           <*> getStackProjects
 
 main :: IO ()
 main = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -64,7 +64,7 @@ getConfig args = do
            <*> pure (args `getArg` longOption "repo-token")
            <*> getGitInfo
            <*> defaultOr args (longOption "hpc-dir") (getHpcDir pn)
-           <*> defaultOr args (longOption "hpc-dir") getMixDir
+           <*> pure (maybe getMixDir (const . return) $ args `getArg` longOption "mix-dir")
            <*> pure (if args `isPresent` longOption "partial-coverage"
                         then PartialLines
                         else FullLines)

--- a/src/SHC/Coverage.hs
+++ b/src/SHC/Coverage.hs
@@ -91,8 +91,7 @@ readCoverageData conf suite = do
                         stackProj =
                           fromMaybe (error $ "readCoverageData/filePath/stackProj: couldn't find " ++ pkgKey) $
                           find ((== pkgKey) . stackProjectKey) (stackProjects conf)
-                    dir <- SHC.Types.mixDir conf (stackProjectPath stackProj)
-                    mix@(Mix origFp _ _ _ _) <- readMix [dir] (Right tixModule)
+                    mix@(Mix origFp _ _ _ _) <- readMix [fromMaybe (stackProjectMixDir stackProj) (mixDir conf)] (Right tixModule)
                     let fp = normalise $ maybe id (</>) (stackProjectPath stackProj) origFp
                     source <- BS.readFile fp
                     return (fp, source, mix, tixs)

--- a/src/SHC/Stack.hs
+++ b/src/SHC/Stack.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE CPP #-}
+-- |
+-- Module:      SHC.Stack
+-- Copyright:   (c) 2014-2015 Guillaume Nargeot, (c) 2015-2016 Felipe Lessa
+-- License:     BSD3
+-- Maintainer:  Michele Lacchia <michelelacchia@gmail.com>
+-- Stability:   experimental
+--
+-- Utility functions related to Stack.
+
+module SHC.Stack
+    where
+
+import Data.Version
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>), (<*>))
+#endif
+import Control.Monad (forM, guard)
+import System.Directory (makeRelativeToCurrentDirectory)
+import System.FilePath ((</>), equalFilePath)
+
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.Yaml as Y
+
+import SHC.Types
+import SHC.Utils
+
+
+stack :: [String] -> IO String
+stack = readP "stack"
+
+-- | Verify that the required Stack is present.
+checkStackVersion :: IO Bool
+checkStackVersion = do
+    let lowerBound = Version [0,1,7,0] []
+    stackVersion <- stack ["--numeric-version"]
+    return $ verifyVersion stackVersion lowerBound
+
+-- | Return the HPC data directory, given the package name.
+getHpcDir :: String -> IO FilePath
+getHpcDir package = (</> package) <$> stack ["path", "--local-hpc-root"]
+
+-- | Return the HPC mix directory, where module data is stored.
+getMixDir :: IO FilePath
+getMixDir = (</> "hpc") <$> stack ["path", "--dist-dir"]
+
+-- | Get relevant information from @stack query@.  Used to find
+-- package filepaths.
+getStackQuery :: IO StackQuery
+getStackQuery = (Y.decodeEither' . BS8.pack <$> stack ["query"]) >>= either err return
+  where err = fail . (++) "getStackQuery: Couldn't decode the result of 'stack query' as YAML: " . show
+
+-- | Get the key that GHC uses for the given package.
+getProjectKey :: String -> IO String
+getProjectKey pkgName = stack ["exec", "--", "ghc-pkg", "field", pkgName, "key", "--simple-output"]
+
+-- | Get the Stack info needed to find project files.
+getStackProjects :: IO [StackProject]
+getStackProjects = do
+  sq <- getStackQuery
+  forM (stackQueryLocals sq) $ \(pkgName, filepath) -> do
+    relfp <- makeRelativeToCurrentDirectory filepath
+    key   <- getProjectKey pkgName
+    return
+      StackProject
+        { stackProjectName = pkgName
+        , stackProjectPath = guard (not $ relfp `equalFilePath` ".") >> Just relfp
+        , stackProjectKey  = key
+        }

--- a/src/SHC/Stack.hs
+++ b/src/SHC/Stack.hs
@@ -40,9 +40,13 @@ checkStackVersion = do
 getHpcDir :: String -> IO FilePath
 getHpcDir package = (</> package) <$> stack ["path", "--local-hpc-root"]
 
--- | Return the HPC mix directory, where module data is stored.
-getMixDir :: IO FilePath
-getMixDir = (</> "hpc") <$> stack ["path", "--dist-dir"]
+-- | Return the HPC mix directory, where module data is stored, given
+-- the project path (cf. 'stackProjectPath').
+getMixDir :: Maybe FilePath -> IO FilePath
+getMixDir mpath = addPrefix . addSuffix <$> stack ["path", "--dist-dir"]
+  where
+    addPrefix = maybe id (</>) mpath
+    addSuffix = (</> "hpc")
 
 -- | Get relevant information from @stack query@.  Used to find
 -- package filepaths.

--- a/src/SHC/Types.hs
+++ b/src/SHC/Types.hs
@@ -43,6 +43,7 @@ data Config = Config
     , mixDir        :: Maybe FilePath
     , conversion    :: ConversionType
     , stackProjects :: [StackProject]
+    , fetchCoverage :: Bool
     }
 
 data GitInfo = GitInfo

--- a/src/SHC/Types.hs
+++ b/src/SHC/Types.hs
@@ -3,7 +3,10 @@
 module SHC.Types
     where
 
+import           Control.Monad (forM)
 import           Data.Aeson
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Text           as T
 import           Trace.Hpc.Mix
 
 
@@ -30,14 +33,16 @@ data PostResult = PostSuccess String
                 deriving (Show)
 
 data Config = Config
-    { suitesName  :: [String]
-    , serviceName :: String
-    , jobId       :: String
-    , repoToken   :: Maybe String
-    , gitInfo     :: GitInfo
-    , hpcDir      :: FilePath
-    , mixDir      :: FilePath
-    , conversion  :: ConversionType
+    { packageName   :: String
+    , suitesName    :: [String]
+    , serviceName   :: String
+    , jobId         :: String
+    , repoToken     :: Maybe String
+    , gitInfo       :: GitInfo
+    , hpcDir        :: FilePath
+    , mixDir        :: FilePath
+    , conversion    :: ConversionType
+    , stackProjects :: [StackProject]
     }
 
 data GitInfo = GitInfo
@@ -79,3 +84,34 @@ instance ToJSON Remote where
     toJSON r = object [ "name" .= name r
                       , "url"  .= url r
                       ]
+
+-- | Data returned by the @stack query@ command.
+data StackQuery =
+  StackQuery
+  { stackQueryLocals :: [(String, FilePath)]
+    -- ^ A list of pairs of @(package-name, filepath)@, where the
+    -- @filepath@ is the absolute 'FilePath' where @package-name@ is
+    -- located.
+  } deriving (Show)
+
+instance FromJSON StackQuery where
+  parseJSON = withObject "StackQuery" $ \o -> StackQuery <$> (o .: "locals" >>= parseLocals)
+    where
+      parseLocals =
+        withObject "StackQuery/locals" $ \o ->
+          forM (HM.toList o) $ \(pkgName, val) -> do
+            filepath <- withObject "StackQuery/locals/package" (.: "path") val
+            return (T.unpack pkgName, filepath)
+
+
+-- | Information we've collected about a stack project.
+data StackProject =
+  StackProject
+  { stackProjectName :: String
+    -- ^ The name of this project.
+  , stackProjectPath :: Maybe FilePath
+    -- ^ Path of the project relative to current path.  @Nothing@ iff
+    -- the project's path is the current path.
+  , stackProjectKey  :: String
+    -- ^ Key that @ghc-pkg@ uses for this project.
+  } deriving (Show)

--- a/src/SHC/Types.hs
+++ b/src/SHC/Types.hs
@@ -40,7 +40,7 @@ data Config = Config
     , repoToken     :: Maybe String
     , gitInfo       :: GitInfo
     , hpcDir        :: FilePath
-    , mixDir        :: (Maybe FilePath -> IO FilePath)
+    , mixDir        :: Maybe FilePath
     , conversion    :: ConversionType
     , stackProjects :: [StackProject]
     }
@@ -107,11 +107,13 @@ instance FromJSON StackQuery where
 -- | Information we've collected about a stack project.
 data StackProject =
   StackProject
-  { stackProjectName :: String
+  { stackProjectName   :: String
     -- ^ The name of this project.
-  , stackProjectPath :: Maybe FilePath
+  , stackProjectPath   :: Maybe FilePath
     -- ^ Path of the project relative to current path.  @Nothing@ iff
     -- the project's path is the current path.
-  , stackProjectKey  :: String
+  , stackProjectKey    :: String
     -- ^ Key that @ghc-pkg@ uses for this project.
+  , stackProjectMixDir :: FilePath
+    -- ^ The project's mix dir (cf. 'getMixDir').
   } deriving (Show)

--- a/src/SHC/Types.hs
+++ b/src/SHC/Types.hs
@@ -40,7 +40,7 @@ data Config = Config
     , repoToken     :: Maybe String
     , gitInfo       :: GitInfo
     , hpcDir        :: FilePath
-    , mixDir        :: FilePath
+    , mixDir        :: (Maybe FilePath -> IO FilePath)
     , conversion    :: ConversionType
     , stackProjects :: [StackProject]
     }

--- a/src/SHC/Types.hs
+++ b/src/SHC/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP, OverloadedStrings #-}
 
 module SHC.Types
     where
@@ -8,6 +8,10 @@ import           Data.Aeson
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text           as T
 import           Trace.Hpc.Mix
+
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>))
+#endif
 
 
 data ConversionType = FullLines

--- a/src/SHC/Utils.hs
+++ b/src/SHC/Utils.hs
@@ -46,7 +46,7 @@ getGitInfo = GitInfo <$> headRef <*> branchName <*> getRemotes
           branchName = git ["rev-parse", "--abbrev-ref", "HEAD"]
 
 getRemotes :: IO [Remote]
-getRemotes = nubBy ((==) `on` name) <$> parseRemotes <$> git ["remote", "-v"]
+getRemotes = nubBy ((==) `on` name) . parseRemotes <$> git ["remote", "-v"]
     where parseRemotes :: String -> [Remote]
           parseRemotes input = do
             line <- lines input

--- a/src/SHC/Utils.hs
+++ b/src/SHC/Utils.hs
@@ -19,7 +19,6 @@ import           Data.Version
 import           Control.Applicative ((<$>), (<*>))
 #endif
 import           Text.ParserCombinators.ReadP
-import           System.FilePath     ((</>))
 import           System.Process      (readProcess)
 
 import           SHC.Types
@@ -30,9 +29,6 @@ readP cmd args = init <$> readProcess cmd args []  -- strip trailing \n
 
 git :: [String] -> IO String
 git = readP "git"
-
-stack :: [String] -> IO String
-stack = readP "stack"
 
 -- | Get information about the Git repo in the current directory.
 getGitInfo :: IO GitInfo
@@ -54,27 +50,12 @@ getRemotes = nubBy ((==) `on` name) . parseRemotes <$> git ["remote", "-v"]
             guard $ length fields >= 2
             return $ Remote (head fields) (fields !! 1)
 
--- | Verify that the required Stack is present.
-checkStackVersion :: IO Bool
-checkStackVersion = do
-    let lowerBound = Version [0,1,7,0] []
-    stackVersion <- stack ["--numeric-version"]
-    return $ verifyVersion stackVersion lowerBound
-
 -- | Check whether a string is a version and if it is
 -- greater than or equal to a specified version.
 verifyVersion :: String -> Version -> Bool
 verifyVersion ver lowerBound =
         let parses = readP_to_S parseVersion ver
         in  not (null parses) && (lowerBound <= fst (last parses))
-
--- | Return the HPC data directory, given the package name.
-getHpcDir :: String -> IO FilePath
-getHpcDir package = (</> package) <$> stack ["path", "--local-hpc-root"]
-
--- | Return the HPC mix directory, where module data is stored.
-getMixDir :: IO FilePath
-getMixDir = (</> "hpc") <$> stack ["path", "--dist-dir"]
 
 fst3 :: (a, b, c) -> a
 fst3 (x, _, _) = x

--- a/stack-hpc-coveralls.cabal
+++ b/stack-hpc-coveralls.cabal
@@ -22,20 +22,24 @@ library
                        SHC.Utils
                        SHC.Lix
                        SHC.Api
-  build-depends:       base           >=4.7  && <5
-                     , hpc            >=0.6
-                     , filepath       >=1.3
-                     , process        >=1.2
-                     , pureMD5        >=2.1
-                     , containers     >=0.5
-                     , aeson          >=0.8
-                     , bytestring     >=0.10
-                     , utf8-string    >=1
-                     , text           >=1.2
-                     , wreq           >=0.3
-                     , http-client    >=0.4
-                     , lens           >=4.7
-                     , lens-aeson     >=1.0
+                       SHC.Stack
+  build-depends:       base                 >=4.7  && <5
+                     , hpc                  >=0.6
+                     , directory            >=1.0
+                     , filepath             >=1.3
+                     , process              >=1.2
+                     , pureMD5              >=2.1
+                     , containers           >=0.5
+                     , aeson                >=0.8
+                     , bytestring           >=0.10
+                     , unordered-containers >=0.2
+                     , utf8-string          >=1
+                     , text                 >=1.2
+                     , wreq                 >=0.3
+                     , http-client          >=0.4
+                     , lens                 >=4.7
+                     , lens-aeson           >=1.0
+                     , yaml                 >=0.8
   default-language:    Haskell2010
 
 executable shc

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.11
+resolver: lts-3.20
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
This pull request makes `stack-hpc-coveralls` compatible with `stack.yaml` files that have more than one Cabal project.  It also allows the tool to be used with private repos, as fetching the resulting URL is not the default anymore.
