### PR TITLE
Upversion stack resolver

### DIFF
--- a/src/SHC/Api.hs
+++ b/src/SHC/Api.hs
@@ -45,8 +45,8 @@ sendData conf url json = do
        else return . PostFailure $ formatResponseError r
     where fileName    = serviceName conf ++ "-" ++ jobId conf ++ ".json"
           requestBody = RequestBodyLBS $ encode json
-          httpOptions = defaults & checkStatus .~ Just noCheck
-          noCheck _ _ _ = Nothing
+          httpOptions = defaults & checkResponse .~ Just noCheck
+          noCheck _ _ = return ()
 
 readResponse :: Response LBS.ByteString -> PostResult
 readResponse r =

--- a/src/SHC/Api.hs
+++ b/src/SHC/Api.hs
@@ -45,7 +45,7 @@ sendData conf url json = do
        else return . PostFailure $ formatResponseError r
     where fileName    = serviceName conf ++ "-" ++ jobId conf ++ ".json"
           requestBody = RequestBodyLBS $ encode json
-          httpOptions = defaults & checkResponse .~ Just noCheck
+          httpOptions = defaults & checkResponse ?~ noCheck
           noCheck _ _ = return ()
 
 readResponse :: Response LBS.ByteString -> PostResult

--- a/stack-hpc-coveralls.cabal
+++ b/stack-hpc-coveralls.cabal
@@ -77,7 +77,7 @@ test-suite style
   hs-source-dirs:      test
   main-is:             HLint.hs
   build-depends:       base  >=4.7 && <5
-                     , hlint ==1.*
+                     , hlint ==2.*
   default-language:    Haskell2010
   ghc-options:         -Wall
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: nightly-2016-06-15
+resolver: lts-11.5
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
This is my attempt to fix issue #19, which I hit when trying to do a `stack install stack-hpc-coveralls` in a project using a newer resolver.